### PR TITLE
Add TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,15 @@
 
-export function logger(output?: Function, verbose?: boolean): Middleware;
+export function logger(output?: (arg1: any, arg2: any) => any, verbose?: boolean): Middleware
 export const immutable: Middleware;
-export function compose(...middlewares: Middleware[]): Middleware;
+export function compose(...middlewares: MiddlewareOrFalsy[]): Middleware;
+export function middleware(fn: (action: any, props: any) => any): Middleware;
+export const omitStateReturn: Middleware;
 
+export function onState(cb: (state: any) => any): Middleware;
+export function onAction(cb: (action: Function) => any): Middleware;
+export function onTuple(cb: (tuple: [Function, ...any[]]) => any): Middleware;
+export function onEffect(cb: (effect: Effect) => any): Middleware;
+
+type MiddlewareOrFalsy = (Middleware | false | null | undefined);
 type Middleware = (baseDispatch: (action: any, props: any) => any) => ((action: any, props: any) => any);
+type Effect = [Function] | [Function, any];

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export const omitStateReturn: Middleware;
 
 export function onState(cb: (state: any) => any): Middleware;
 export function onAction(cb: (action: Function) => any): Middleware;
-export function onTuple(cb: (tuple: [Function, ...any[]]) => any): Middleware;
+export function onTuple(cb: (tuple: [Function, any]) => any): Middleware;
 export function onEffect(cb: (effect: Effect) => any): Middleware;
 
 type MiddlewareOrFalsy = (Middleware | false | null | undefined);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+
+export function logger(output?: Function, verbose?: boolean): Middleware;
+export const immutable: Middleware;
+export function compose(...middlewares: Middleware[]): Middleware;
+
+type Middleware = (baseDispatch: (action: any, props: any) => any) => ((action: any, props: any) => any);

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "main": "dist/middlewares.js",
   "module": "src/index.js",
+  "typings": "index.d.ts",
   "scripts": {
     "test": "exit 0",
     "prebuild": "npm run test",


### PR DESCRIPTION
I added a TypeScript type declaration (`index.d.ts`) so that you can use it with TypeScript just by installing your middlewares. I'd be happy if you can merge them.